### PR TITLE
fix(ios): replace placeholder with actual Google Maps API key

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,8 +9,7 @@ import UIKit
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
 
-    // TODO: Add your Google Maps API key
-    GMSServices.provideAPIKey("YOUR-API-KEY") 
+    GMSServices.provideAPIKey("AIzaSyBPmbfVbuXVaMZbFQvE7KNcsQ4ATCT8q5Q") 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }


### PR DESCRIPTION
The placeholder API key was replaced with a valid one to enable Google Maps functionality in the iOS app.