### PR TITLE
feat(auth): add client IDs and simplify google sign-in

### DIFF
--- a/lib/data/datasources/services/auth_service.dart
+++ b/lib/data/datasources/services/auth_service.dart
@@ -30,11 +30,7 @@ class AuthService {
       developer.log('Starting Google Sign-In process', name: 'AuthService');
       await _googleSignIn.initialize();
       // Step 1: Sign in with Google
-      final googleUser = await _googleSignIn.attemptLightweightAuthentication();
-
-      if (googleUser == null) {
-        throw AuthException('Google Sign-In was cancelled by user');
-      }
+      final googleUser = await _googleSignIn.authenticate();
 
       developer.log(
         'Google Sign-In successful for: ${googleUser.email}',

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -63,6 +63,9 @@ class DefaultFirebaseOptions {
     messagingSenderId: '815598506761',
     projectId: 'lokapandu-29bc5',
     storageBucket: 'lokapandu-29bc5.firebasestorage.app',
+    androidClientId: '815598506761-j8c2icgmo1h77a6or9nbu900kdgnltsb.apps.googleusercontent.com',
+    iosClientId: '815598506761-ho0ck3e9k89r8v5eutsg1mvhg2o6raup.apps.googleusercontent.com',
     iosBundleId: 'id.lokapandu.lokapandu',
   );
+
 }


### PR DESCRIPTION
Add Android and iOS client IDs to Firebase options. Replace lightweight authentication with standard authenticate method in Google Sign-In flow to simplify the process.